### PR TITLE
Update cli.js

### DIFF
--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node
 "use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };


### PR DESCRIPTION
fix shebang error on Linux
```
/usr/bin/env: ‘node\r’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```